### PR TITLE
Feature/11 53 トップレベルのlayouttsxにヘッダーを移行

### DIFF
--- a/app/components/common/context-provider/app-bar-context-provider.tsx
+++ b/app/components/common/context-provider/app-bar-context-provider.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { getPathnameTitle } from "@/app/model/shared/pathname";
+import { usePathname } from "next/navigation";
+import React, { createContext, useState } from "react";
+export type TProps = {
+  title: string;
+  setTitle: React.Dispatch<React.SetStateAction<string>>;
+};
+
+export const AppBarTitle = createContext<TProps>({
+  title: "",
+  setTitle: () => undefined,
+});
+
+export default function AppBarContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [title, setTitle] = useState<string>(getPathnameTitle(pathname));
+  return (
+    <AppBarTitle.Provider value={{ title, setTitle }}>
+      {children}
+    </AppBarTitle.Provider>
+  );
+}

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { AppBar, Typography } from "@mui/material";
+import { useContext, useEffect } from "react";
+import { AppBarTitle } from "./common/context-provider/app-bar-context-provider";
+import { usePathname } from "next/navigation";
+import { getPathnameTitle } from "../model/shared/pathname";
+
+export default function Header() {
+  const { title, setTitle } = useContext(AppBarTitle);
+  const pathname = usePathname();
+  useEffect(() => {
+    setTitle(getPathnameTitle(pathname) ?? "");
+  }, [pathname, setTitle]);
+  return (
+    <AppBar position="static">
+      <Typography variant="h6" m={1.5}>
+        {title}
+      </Typography>
+    </AppBar>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import Providers from "./providers";
+import AppBarContextProvider from "./components/common/context-provider/app-bar-context-provider";
+import Header from "./components/header";
 
 export const metadata = {
   title: "Manene",
@@ -14,7 +16,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body style={{ margin: 0 }}>
-        <Providers>{children}</Providers>
+        <AppBarContextProvider>
+          <Header />
+          <Providers>{children}</Providers>
+        </AppBarContextProvider>
       </body>
     </html>
   );

--- a/app/model/shared/pathname.ts
+++ b/app/model/shared/pathname.ts
@@ -1,0 +1,10 @@
+export const getPathnameTitle = (pathname: string) => {
+  switch (pathname) {
+    case "/":
+      return "メニュー";
+    case "/coorde_pick":
+      return "コーデピック";
+    default:
+      throw Error("存在しないパスです");
+  }
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import MenuAccordion from "./components/common/accordion/menu-accordion";
 import LinkButton from "./components/common/button/link-button";
 


### PR DESCRIPTION
ヘッダーをtopのlayout.tsxで管理する。
usecontextでページのパスごとに、ヘッダーに表示する文言を動的にした。
