### PR TITLE
feat: Item Mediumカードの作成

### DIFF
--- a/app/components/wasted_reason/wasted-reason-item-medium-card.tsx
+++ b/app/components/wasted_reason/wasted-reason-item-medium-card.tsx
@@ -15,18 +15,13 @@ type TProps = {
 
 export default function WastedReasonItemMediumCard({ itemInfo }: TProps) {
   return (
-    <Box
-      sx={{
-        display: "flex",
-        padding: "7%",
-      }}
-    >
+    <Box display={"flex"} padding={"7%"}>
       <Box>
         <ExpandableImage imagePath={itemInfo.itemImageUrl} />
       </Box>
       <Box
+        paddingLeft={"3%"}
         sx={{
-          paddingLeft: "3%",
           color: "secondary.dark",
         }}
       >

--- a/app/components/wasted_reason/wasted-reason-item-medium-card.tsx
+++ b/app/components/wasted_reason/wasted-reason-item-medium-card.tsx
@@ -1,0 +1,43 @@
+import { Box } from "@mui/material";
+import ExpandableImage from "../common/Image/expandable-image";
+
+type TProps = {
+  itemInfo: {
+    id: number;
+    itemImageUrl: string;
+    mBrand: string;
+    size: string;
+    mCateSmall: string;
+    mColor: string;
+    status: string;
+  };
+};
+
+export default function WastedReasonItemMediumCard({ itemInfo }: TProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        padding: "7%",
+      }}
+    >
+      <Box>
+        <ExpandableImage imagePath={itemInfo.itemImageUrl} />
+      </Box>
+      <Box
+        sx={{
+          paddingLeft: "3%",
+          color: "secondary.dark",
+        }}
+      >
+        id: {itemInfo.id} {itemInfo.mBrand}
+        <br />
+        {itemInfo.size} / {itemInfo.mCateSmall} / {itemInfo.mColor}
+        <br />
+        <span style={{ color: "red" }}>
+          現在のステータス: {itemInfo.status}
+        </span>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
お時間ある時に確認お願いします！

![2023-08-28 17 49のイメージ](https://github.com/KiizanKiizan/Manene/assets/124031379/9117c6fe-9c59-4a78-b828-aa0d17368612)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- 新機能：`WastedReasonItemMediumCard`という新しいコンポーネントを追加しました。このコンポーネントは、アイテムの詳細情報（`id`、`itemImageUrl`、`mBrand`、`size`、`mCateSmall`、`mColor`、`status`）を表示するためのものです。
- 新機能：`ExpandableImage`コンポーネントを使用して、アイテムの画像を拡大表示できるようになりました。これにより、ユーザーはアイテムの詳細をより詳しく確認することが可能になります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->