### PR TITLE
Bugfix/193 bugfix棚卸し完了した後に正しく棚データが取得できるようにする

### DIFF
--- a/app/components/common/pages/header.tsx
+++ b/app/components/common/pages/header.tsx
@@ -1,29 +1,7 @@
 "use client";
-import dynamic from "next/dynamic";
+import { AppBar, Box, Button, Toolbar } from "@mui/material";
 import Link from "next/link";
 import React from "react";
-const AppBar = dynamic(
-  () => import("@mui/material").then((mod) => mod.AppBar),
-  {
-    ssr: false,
-  }
-);
-const Box = dynamic(() => import("@mui/material").then((mod) => mod.Box), {
-  ssr: false,
-});
-const Button = dynamic(
-  () => import("@mui/material").then((mod) => mod.Button),
-  {
-    ssr: false,
-  }
-);
-const Toolbar = dynamic(
-  () => import("@mui/material").then((mod) => mod.Toolbar),
-  {
-    ssr: false,
-  }
-);
-
 type TProps = {
   title: string;
   children?: React.ReactNode;

--- a/app/components/stocktaking/stocktaking-container.tsx
+++ b/app/components/stocktaking/stocktaking-container.tsx
@@ -7,7 +7,7 @@ import {
 import useStocktakingsComplete from "@/app/api/stocktaking/useStocktakingsComplete";
 import useStocktakingsCreate from "@/app/api/stocktaking/useStocktakingsCreate";
 import CachedIcon from "@mui/icons-material/Cached";
-import dynamic from "next/dynamic";
+import { Button } from "@mui/material";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import BarcodeButton from "../common/barcode/barcode-button";
@@ -15,13 +15,6 @@ import FooterButton from "../common/button/footer-button";
 import LoadingDialog from "../common/dialog/loading-dialog";
 import Header from "../common/pages/header";
 import StocktakingList from "./stocktaking-list";
-const Button = dynamic(
-  () => import("@mui/material").then((mod) => mod.Button),
-  {
-    ssr: false,
-  }
-);
-
 type TProps = {
   locationList: TStocktakingsCurrentResponse;
 };
@@ -53,6 +46,7 @@ export default function StocktakingContainer({ locationList }: TProps) {
       onSuccess: () => {
         alert(`棚卸しを完了しました`);
         router.push("/");
+        router.refresh();
       },
       onError: (error) => {
         alert(error.message);

--- a/app/components/stocktaking/stocktaking-list.tsx
+++ b/app/components/stocktaking/stocktaking-list.tsx
@@ -1,10 +1,7 @@
 "use client";
 import { TLocation } from "@/app/api/stocktaking/getStocktakingsCurrent";
-import dynamic from "next/dynamic";
+import { List } from "@mui/material";
 import StocktakingRow from "./stocktaking-row";
-const List = dynamic(() => import("@mui/material").then((mod) => mod.List), {
-  ssr: false,
-});
 type TProps = {
   locations: TLocation[];
   onClick: (id: number) => void;
@@ -12,7 +9,7 @@ type TProps = {
 
 export default function StocktakingList({ locations, onClick }: TProps) {
   return (
-    <List>
+    <List disablePadding>
       {locations.map((location) => {
         return (
           <StocktakingRow

--- a/app/stocktaking/page.tsx
+++ b/app/stocktaking/page.tsx
@@ -1,5 +1,11 @@
+import dynamic from "next/dynamic";
 import getStocktakingsCurrent from "../api/stocktaking/getStocktakingsCurrent";
-import StocktakingContainer from "../components/stocktaking/stocktaking-container";
+const StocktakingContainer = dynamic(
+  () => import("../components/stocktaking/stocktaking-container"),
+  {
+    ssr: false,
+  }
+);
 
 export default async function StocktakingPage() {
   const data = await getStocktakingsCurrent();


### PR DESCRIPTION
確認お願いします！

修正前

棚卸しを終了して、再度棚卸しを開くと棚卸しが終了できていない。再度終了ボタンを押すとエラーになり、リロードすると治る。
https://github.com/KiizanKiizan/Manene/assets/105505578/10e21bca-e14d-4121-a2a9-378924fdd301


修正後。

棚卸しを終了して、再度棚卸しを開くと、棚リストがなくなり開始ボタンになる。headerとlistの隙間も無くした。
https://github.com/KiizanKiizan/Manene/assets/105505578/3ddee4a5-9ff8-48f4-9c0f-764ada753b4a


