### PR TITLE
Feature/190/196 chartcardbeforeinspectionslistitemlistの作成

### DIFF
--- a/app/api/before-inspections/useBeforeInspectionsCreate.ts
+++ b/app/api/before-inspections/useBeforeInspectionsCreate.ts
@@ -10,17 +10,19 @@ export type TItemInfo = {
   mBrandName: string;
 };
 
+export type TChartItem = {
+  id: number;
+  itemInfo: TItemInfo;
+  purchasedFlag: boolean;
+  inspectionStatus: number;
+};
+
 export type TChart = {
   id: number;
   tMemberId: number;
   name: string;
   deliveryDate: string;
-  tChartItems: {
-    id: number;
-    itemInfo: TItemInfo;
-    purchasedFlag: boolean;
-    inspectionStatus: number;
-  }[];
+  tChartItems: TChartItem[];
 };
 
 export type TBeforeInspectionsCreateResponse = {

--- a/app/components/before-inspection/before-inspection-list.tsx
+++ b/app/components/before-inspection/before-inspection-list.tsx
@@ -5,7 +5,7 @@ import ItemInfoCard from "../common/Item/item-info-card";
 
 type TProps = {
   chartItems: TChartItem[];
-  onClick: () => void;
+  onClick: (id: number) => void;
   isLoading: boolean;
 };
 
@@ -16,15 +16,19 @@ export default function BeforeInspectionList({
 }: TProps) {
   return (
     <List>
-      {chartItems.map((item: TChartItem) => {
+      {chartItems.map((chartItem: TChartItem) => {
         return (
-          <ItemCard key={item.id} imagePath={item.itemInfo.itemImageUrl}>
+          <ItemCard
+            key={chartItem.id}
+            imagePath={chartItem.itemInfo.itemImageUrl}
+          >
             <ItemInfoCard
-              itemInfo={item.itemInfo}
+              itemInfo={chartItem.itemInfo}
+              chartItemId={chartItem.id}
               onClick={onClick}
               isLoading={isLoading}
-              isPurchased={item.purchasedFlag}
-              inspectionStatus={item.inspectionStatus}
+              isPurchased={chartItem.purchasedFlag}
+              inspectionStatus={chartItem.inspectionStatus}
             />
           </ItemCard>
         );

--- a/app/components/before-inspection/before-inspection-list.tsx
+++ b/app/components/before-inspection/before-inspection-list.tsx
@@ -1,0 +1,34 @@
+import { TChartItem } from "@/app/api/before-inspections/useBeforeInspectionsCreate";
+import { List } from "@mui/material";
+import ItemCard from "../common/Item/item-card";
+import ItemInfoCard from "../common/Item/item-info-card";
+
+type TProps = {
+  chartItems: TChartItem[];
+  onClick: () => void;
+  isLoading: boolean;
+};
+
+export default function BeforeInspectionList({
+  chartItems,
+  onClick,
+  isLoading,
+}: TProps) {
+  return (
+    <List>
+      {chartItems.map((item: TChartItem) => {
+        return (
+          <ItemCard key={item.id} imagePath={item.itemInfo.itemImageUrl}>
+            <ItemInfoCard
+              itemInfo={item.itemInfo}
+              onClick={onClick}
+              isLoading={isLoading}
+              isPurchased={item.purchasedFlag}
+              inspectionStatus={item.inspectionStatus}
+            />
+          </ItemCard>
+        );
+      })}
+    </List>
+  );
+}

--- a/app/components/common/Item/item-card.tsx
+++ b/app/components/common/Item/item-card.tsx
@@ -6,7 +6,7 @@ import ExpandableImage from "../Image/expandable-image";
 
 type TProps = {
   imagePath: string;
-  isItemPicked: boolean;
+  isItemPicked?: boolean;
   children: React.ReactNode;
 };
 
@@ -29,7 +29,7 @@ export default function ItemCard({
         <CheckCircleOutlineSharpIcon sx={{ color: "primary.main", mx: 0.5 }} />
       )}
       <ExpandableImage imagePath={imagePath} />
-      <Box sx={{ ml: 1.5 }}>{children}</Box>
+      <Box sx={{ ml: 1.5, width: "300px" }}>{children}</Box>
     </Box>
   );
 }

--- a/app/components/common/Item/item-info-card.tsx
+++ b/app/components/common/Item/item-info-card.tsx
@@ -1,39 +1,110 @@
 "use client";
-import { TCoordePicksIndexResponse } from "@/app/api/coorde_pick/useCoordePicksIndex";
-import { Box, Typography } from "@mui/material";
-
-type TItemInfo = Omit<TCoordePicksIndexResponse, "itemImageUrl" | "isPicked">;
+import { TItemInfo } from "@/app/api/before-inspections/useBeforeInspectionsCreate";
+import { Box, Button, Typography } from "@mui/material";
+import React, { useMemo } from "react";
 
 type TProps = {
-  itemInfo: TItemInfo;
+  itemInfo: TItemInfo & {
+    mLocationName?: string;
+  };
+  onClick?: () => void;
+  isLoading?: boolean;
+  isPurchased?: boolean;
+  inspectionStatus?: number;
 };
 
-export default function ItemInfoCard({ itemInfo }: TProps) {
+function InspectionStatusText({ children }: { children: React.ReactNode }) {
+  return (
+    <Typography color="warning.dark" variant="body2" marginRight={2}>
+      {children}
+    </Typography>
+  );
+}
+
+export const INSPECTION_STATUS = {
+  RETURNED: 0,
+  MISPLACED: 1,
+  INSPECTED: 2,
+  WASHING: 3,
+  PURCHASE_REQUEST: 4,
+  PURCHASE_CANDIDATE: 5,
+} as const;
+
+export default function ItemInfoCard({
+  itemInfo,
+  onClick,
+  isLoading,
+  isPurchased,
+  inspectionStatus,
+}: TProps) {
+  const statusView = useMemo(() => {
+    return {
+      [INSPECTION_STATUS.RETURNED]: (
+        <Button
+          onClick={onClick}
+          disabled={isLoading}
+          variant="contained"
+          sx={{ marginRight: "15px" }}
+        >
+          入れ忘れ
+        </Button>
+      ),
+      [INSPECTION_STATUS.MISPLACED]: (
+        <InspectionStatusText>入れ忘れ登録済み</InspectionStatusText>
+      ),
+      [INSPECTION_STATUS.INSPECTED]: (
+        <InspectionStatusText>検品済み</InspectionStatusText>
+      ),
+      [INSPECTION_STATUS.WASHING]: (
+        <InspectionStatusText>汚れ確認中</InspectionStatusText>
+      ),
+      [INSPECTION_STATUS.PURCHASE_REQUEST]: (
+        <InspectionStatusText>買取依頼済み</InspectionStatusText>
+      ),
+      [INSPECTION_STATUS.PURCHASE_CANDIDATE]: (
+        <InspectionStatusText>買取候補</InspectionStatusText>
+      ),
+    }[inspectionStatus as number];
+  }, [inspectionStatus, onClick, isLoading]);
+
   return (
     <>
-      <Typography component="div" display={"flex"} fontSize={"h5.fontSize"}>
-        <Box>棚名</Box>
-        <Box sx={{ mx: 1 }}>:</Box>
-        <Box>{itemInfo.mLocationName}</Box>
-      </Typography>
-      <Typography
-        component="div"
-        sx={{
-          display: "flex",
-          justifyContent: "flex-start",
-          fontSize: 17,
-        }}
-      >
-        <Box mr={1.5}>{itemInfo.id}</Box>
-        <Box>{itemInfo.mBrandName}</Box>
-      </Typography>
-      <Typography component="div" display={"flex"} fontSize={17}>
-        <Box>{itemInfo.size}</Box>
-        <Box mx={0.5}>/</Box>
-        <Box>{itemInfo.mCateSmallName}</Box>
-        <Box mx={0.5}>/</Box>
-        <Box>{itemInfo.mColorName}</Box>
-      </Typography>
+      {itemInfo.mLocationName && (
+        <Typography component="div" display={"flex"} fontSize={"h5.fontSize"}>
+          <Box>棚名</Box>
+          <Box sx={{ mx: 1 }}>:</Box>
+          <Box>{itemInfo.mLocationName}</Box>
+        </Typography>
+      )}
+      <Box>
+        <Box>
+          <Typography
+            component="div"
+            sx={{
+              display: "flex",
+              justifyContent: "flex-start",
+              fontSize: 17,
+            }}
+          >
+            <Box mr={1.5}>{itemInfo.id}</Box>
+            <Box>{itemInfo.mBrandName}</Box>
+          </Typography>
+          <Typography component="div" display={"flex"} fontSize={17}>
+            <Box>{itemInfo.size}</Box>
+            <Box mx={0.5}>/</Box>
+            <Box>{itemInfo.mCateSmallName}</Box>
+            <Box mx={0.5}>/</Box>
+            <Box>{itemInfo.mColorName}</Box>
+          </Typography>
+        </Box>
+        <Box display="flex" alignItems="center" justifyContent="end">
+          {isPurchased ? (
+            <InspectionStatusText>購入済み</InspectionStatusText>
+          ) : (
+            statusView
+          )}
+        </Box>
+      </Box>
     </>
   );
 }

--- a/app/components/common/Item/item-info-card.tsx
+++ b/app/components/common/Item/item-info-card.tsx
@@ -7,7 +7,8 @@ type TProps = {
   itemInfo: TItemInfo & {
     mLocationName?: string;
   };
-  onClick?: () => void;
+  chartItemId: number;
+  onClick?: (id: number) => void;
   isLoading?: boolean;
   isPurchased?: boolean;
   inspectionStatus?: number;
@@ -32,6 +33,7 @@ export const INSPECTION_STATUS = {
 
 export default function ItemInfoCard({
   itemInfo,
+  chartItemId,
   onClick,
   isLoading,
   isPurchased,
@@ -41,7 +43,11 @@ export default function ItemInfoCard({
     return {
       [INSPECTION_STATUS.RETURNED]: (
         <Button
-          onClick={onClick}
+          onClick={() => {
+            if (onClick) {
+              onClick(chartItemId);
+            }
+          }}
           disabled={isLoading}
           variant="contained"
           sx={{ marginRight: "15px" }}
@@ -65,7 +71,7 @@ export default function ItemInfoCard({
         <InspectionStatusText>買取候補</InspectionStatusText>
       ),
     }[inspectionStatus as number];
-  }, [inspectionStatus, onClick, isLoading]);
+  }, [inspectionStatus, onClick, isLoading, chartItemId]);
 
   return (
     <>

--- a/app/components/common/Item/item-info-card.tsx
+++ b/app/components/common/Item/item-info-card.tsx
@@ -7,7 +7,7 @@ type TProps = {
   itemInfo: TItemInfo & {
     mLocationName?: string;
   };
-  chartItemId: number;
+  chartItemId?: number;
   onClick?: (id: number) => void;
   isLoading?: boolean;
   isPurchased?: boolean;
@@ -44,7 +44,7 @@ export default function ItemInfoCard({
       [INSPECTION_STATUS.RETURNED]: (
         <Button
           onClick={() => {
-            if (onClick) {
+            if (onClick && chartItemId) {
               onClick(chartItemId);
             }
           }}

--- a/app/components/common/card/chart-card.tsx
+++ b/app/components/common/card/chart-card.tsx
@@ -1,0 +1,50 @@
+import { TChart as TProps } from "@/app/api/before-inspections/useBeforeInspectionsCreate";
+import { Box, Card, Typography } from "@mui/material";
+
+export default function ChartCard({
+  id,
+  tMemberId,
+  name,
+  deliveryDate,
+  tChartItems,
+}: TProps) {
+  return (
+    <Card
+      sx={{
+        width: "95%",
+        marginLeft: "auto",
+        marginRight: "auto",
+        bgcolor: "secondary.light",
+      }}
+    >
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        paddingY="1px"
+        paddingX={3}
+      >
+        <Box>
+          <Typography variant="caption">
+            カルテID: {id}/発送日: {deliveryDate}
+          </Typography>
+          <Typography variant="body2">
+            {name}: {tMemberId}
+          </Typography>
+        </Box>
+        <Box display="flex" alignItems="center">
+          <Typography
+            variant="h6"
+            color="primary.main"
+            component="span"
+            marginRight={1}
+          >
+            {tChartItems.length}
+          </Typography>
+          <Typography variant="subtitle1" component="span">
+            アイテム
+          </Typography>
+        </Box>
+      </Box>
+    </Card>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,7 +6,7 @@ import React from "react";
 const themeOptions: ThemeOptions = {
   palette: {
     primary: { main: "#1976d2" },
-    secondary: { main: "#bdbdbd" },
+    secondary: { main: "#bdbdbd", light: "#d3d3d3" },
     success: { main: "#DDFFDD" },
     warning: { main: "#FADBDA", dark: "#ff0000", light: "#fd7e00" },
   },


### PR DESCRIPTION
ご確認よろしくお願いします！

ChartCard:

<img width="338" alt="スクリーンショット 2023-09-01 16 47 57" src="https://github.com/KiizanKiizan/Manene/assets/105505578/db7155ad-ba1e-4b2c-a771-3859401e30fc">

BeforeInspectionList: 

![スクリーンショット 2023-09-02 13 04 46](https://github.com/KiizanKiizan/Manene/assets/105505578/5e4746aa-d78a-4f46-aa05-ff387485e626)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

リリースノート:

- 新機能: `BeforeInspectionList`コンポーネントを追加しました。これにより、検査前のアイテムリストが表示されます。
- 新機能: `ItemInfoCard`コンポーネントに新たなプロパティ（`mLocationName`, `onClick`, `isLoading`, `isPurchased`, `inspectionStatus`）を追加し、検査状況に基づいて表示を変更する機能を追加しました。
- 新機能: `ChartCard`コンポーネントを追加しました。これにより、チャート情報をカード形式で表示します。
- スタイル: テーマオプションに新たな色設定を追加し、UIのカスタマイズ性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->