### PR TITLE
Feature/214/220 cleaningcostscontainer page作成

### DIFF
--- a/app/api/cleaning-costs/getCreaningCostsChoice.ts
+++ b/app/api/cleaning-costs/getCreaningCostsChoice.ts
@@ -1,13 +1,13 @@
 import getNoCacheData from "../getNoCacheData";
 
-type TCleaningCostsResponse = {
+export type TCleaningCostsResponse = {
   id: number;
   name: string;
   baseCost: number;
-}[];
+};
 
 export default async function getCleaningCostsChoices() {
-  return await getNoCacheData<TCleaningCostsResponse>({
-    path: "cleaning_costs/choice"
+  return await getNoCacheData<TCleaningCostsResponse[]>({
+    path: "cleaning_costs/choice",
   });
 }

--- a/app/cleaning_costs/layout.tsx
+++ b/app/cleaning_costs/layout.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import Header from "../components/common/pages/header";
+
+export default function CleaningCostsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <Header title="クリーニングコスト登録" />
+      {children}
+    </section>
+  );
+}

--- a/app/cleaning_costs/page.tsx
+++ b/app/cleaning_costs/page.tsx
@@ -1,0 +1,7 @@
+import getCleaningCostsChoices from "../api/cleaning-costs/getCreaningCostsChoice";
+import CleaningCostsContainer from "../components/cleaning-costs/cleaning-costs-container";
+
+export default async function CleaningCostsPage() {
+  const data = await getCleaningCostsChoices();
+  return <CleaningCostsContainer cleaningOptions={data} />;
+}

--- a/app/components/cleaning-costs/cleaning-costs-container.tsx
+++ b/app/components/cleaning-costs/cleaning-costs-container.tsx
@@ -1,0 +1,154 @@
+"use client";
+import fetchCleaningCostsItemDetail from "@/app/api/cleaning-costs/fetchCleaningCostsItemDetail";
+import { TCleaningCostsResponse } from "@/app/api/cleaning-costs/getCreaningCostsChoice";
+import useCleaningCostsCreate from "@/app/api/cleaning-costs/useCleaningCostsCreate";
+import {
+  Box,
+  Button,
+  FormControl,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { AxiosError } from "axios";
+import { ChangeEvent, useState } from "react";
+import QrCodeReader from "../common/barcode/qr-code-reader";
+import LoadingDialog from "../common/dialog/loading-dialog";
+import CleaningCostsList from "./cleaning-costs-list";
+import { TItem } from "./cleaning-costs-list-item";
+
+type TProps = {
+  cleaningOptions: TCleaningCostsResponse[];
+};
+export default function CleaningCostsContainer({ cleaningOptions }: TProps) {
+  const [selectedOptionId, setSelectedOptionId] = useState<number>();
+  const [inputtedCost, setInputtedCost] = useState<number>();
+  const [items, setItems] = useState<TItem[]>([]);
+  const { mutate, isLoading } = useCleaningCostsCreate();
+
+  const isItemSelected = (targetId: number): boolean => {
+    return items.some((item) => item.id === targetId);
+  };
+  const handleScan = (id: number) => {
+    isItemSelected(id)
+      ? alert(`アイテム(ID: ${id})は既にスキャンしています。`)
+      : fetchCleaningCostsItemDetail({ tItemId: id })
+          .then((data: TItem) => setItems([...items, data]))
+          .catch((error) => alert(error.message));
+  };
+
+  const handleRegister = () => {
+    if (items.length > 0 && selectedOptionId && inputtedCost) {
+      mutate(
+        {
+          mCleaningCategoryId: selectedOptionId,
+          tItemIds: items.map((item) => item.id),
+          cost: inputtedCost,
+        },
+        {
+          onSuccess: () => {
+            alert("クリーニングコスト登録が完了しました。");
+            setItems([]);
+          },
+          onError(error: AxiosError) {
+            alert(
+              `登録に失敗しました。 ${
+                (error.response?.data as { message: string })?.message
+              }`
+            );
+          },
+        }
+      );
+    }
+  };
+
+  return (
+    <>
+      <LoadingDialog isOpen={isLoading} />
+      <QrCodeReader onScan={(id: number) => handleScan(id)} isRectangle />
+      <Typography>読取件数: {items.length}</Typography>
+      {items && (
+        <Box overflow="auto" height={430}>
+          <CleaningCostsList items={items} />
+        </Box>
+      )}
+      <Box
+        marginBottom={3}
+        position="fixed"
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        bottom={0}
+        left="50%"
+        sx={{
+          width: "90%",
+          transform: "translateX(-50%)",
+        }}
+      >
+        <Box marginBottom={2} display="flex" justifyContent={"space-between"}>
+          <FormControl sx={{ width: "45%" }}>
+            <InputLabel>クリーニング内容</InputLabel>
+            <Select
+              value={selectedOptionId ?? ""}
+              label="option-id"
+              onChange={(e: SelectChangeEvent<number>) => {
+                setSelectedOptionId(e.target.value as number);
+                setInputtedCost(
+                  cleaningOptions.find(
+                    (option: TCleaningCostsResponse) =>
+                      option.id === e.target.value
+                  )?.baseCost
+                );
+              }}
+            >
+              {cleaningOptions.map((option) => {
+                return (
+                  <MenuItem key={option.id} value={option.id}>
+                    {option.name}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+          <TextField
+            type="number"
+            label="コスト"
+            value={inputtedCost}
+            onChange={(
+              e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+            ) => {
+              setInputtedCost(
+                isNaN(parseInt(e.target.value))
+                  ? undefined
+                  : parseInt(e.target.value)
+              );
+            }}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            sx={{ width: "45%" }}
+            InputProps={{
+              endAdornment: <InputAdornment position="end">円</InputAdornment>,
+            }}
+          />
+        </Box>
+        <Button
+          variant="contained"
+          onClick={handleRegister}
+          sx={{ height: "50px" }}
+          disabled={
+            items.length < 1 ||
+            selectedOptionId === undefined ||
+            inputtedCost === undefined
+          }
+        >
+          登録
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
       <Header title="メニュー" />
       <MenuAccordion title="運営">
         <LinkButton buttonName="アイテムサイズ計測" path="" />
-        <LinkButton buttonName="クリーニングコスト登録" path="" />
+        <LinkButton buttonName="クリーニングコスト登録" path="cleaning_costs" />
       </MenuAccordion>
       <MenuAccordion title="返却検品">
         <LinkButton buttonName="返却検品前登録" path="before_inspection" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
       <Header title="メニュー" />
       <MenuAccordion title="運営">
         <LinkButton buttonName="アイテムサイズ計測" path="" />
-        <LinkButton buttonName="クリーニングコスト登録" path="" />
+        <LinkButton buttonName="クリーニングコスト登録" path="cleaning_costs" />
       </MenuAccordion>
       <MenuAccordion title="返却検品">
         <LinkButton buttonName="返却検品前登録" path="before_inspection" />
@@ -30,7 +30,7 @@ export default function HomePage() {
           path="item_status"
         />
         <LinkButton buttonName="廃棄登録" path="" />
-        <LinkButton buttonName="廃棄判定" path="" />
+        <LinkButton buttonName="廃棄判定" path="judge_throw_away" />
       </MenuAccordion>
       <MenuAccordion title="棚管理">
         <LinkButton buttonName="棚移動" path="item_location" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
       <Header title="メニュー" />
       <MenuAccordion title="運営">
         <LinkButton buttonName="アイテムサイズ計測" path="" />
-        <LinkButton buttonName="クリーニングコスト登録" path="cleaning_costs" />
+        <LinkButton buttonName="クリーニングコスト登録" path="" />
       </MenuAccordion>
       <MenuAccordion title="返却検品">
         <LinkButton buttonName="返却検品前登録" path="before_inspection" />
@@ -30,7 +30,7 @@ export default function HomePage() {
           path="item_status"
         />
         <LinkButton buttonName="廃棄登録" path="" />
-        <LinkButton buttonName="廃棄判定" path="judge_throw_away" />
+        <LinkButton buttonName="廃棄判定" path="" />
       </MenuAccordion>
       <MenuAccordion title="棚管理">
         <LinkButton buttonName="棚移動" path="item_location" />


### PR DESCRIPTION
ご確認よろしくお願いします！

https://github.com/KiizanKiizan/Manene/assets/105505578/71f91003-7e79-4201-94fb-b1d7d7ff84d1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

新機能:
- "クリーニングコスト登録"という新しいセクションを追加しました。これにより、ユーザーはQRコードをスキャンしてアイテムの詳細を取得し、クリーニングオプションを選択し、コストを入力し、クリーニングコストを登録することができます。
- ホームページにある"クリーニングコスト登録"と"判定・廃棄"へのリンクボタンのパスを更新しました。

リファクタ:
- `getCleaningCostsChoices`関数の戻り値の型を`Promise<TCleaningCostsResponse[]>`に変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->