### PR TITLE
Feature/183/186 judgethrowawayitemlistjudgethrowawayitemlistitem作成

### DIFF
--- a/app/components/judge-throw-away/judge-throw-away-list-item.tsx
+++ b/app/components/judge-throw-away/judge-throw-away-list-item.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { TItemsJudgeThrowAwayResponse as TProps } from "@/app/api/judge_throw_away/useItemsJudgeThrowAway";
+import { Box, Typography } from "@mui/material";
+import ItemCard from "../common/Item/item-card";
+import ItemInfoCard from "../common/Item/item-info-card";
+
+const JUDGEMENT = {
+  0: "修繕",
+  1: "廃棄",
+};
+
+export default function JudgeThrowAwayListItem({
+  result,
+  item,
+  condition,
+  repairMethod,
+  costDifference,
+}: TProps) {
+  return (
+    <ItemCard imagePath={item.itemImageUrl}>
+      <Box marginY={1} marginLeft={2}>
+        <Typography color="primary.main">登録内容</Typography>
+        <Box marginLeft={1}>
+          <ItemInfoCard
+            itemInfo={{
+              id: item.id,
+              size: item.size ?? "",
+              itemImageUrl: item.itemImageUrl,
+              mCateSmallName: item.mCateSmall.name,
+              mColorName: item.mColor.name,
+              mBrandName: item.mBrand.name,
+            }}
+          />
+        </Box>
+        <Typography color="primary.main">判定条件</Typography>
+        <Typography marginLeft={1}>
+          {condition}/{repairMethod}
+        </Typography>
+        <Typography color="primary.main">
+          修繕コストと修繕後価格の差額
+        </Typography>
+        <Typography marginLeft={1}>{costDifference}円</Typography>
+        <Typography color="primary.main">アイテム使用回数</Typography>
+        <Typography marginLeft={1}>{item.usedCount}回</Typography>
+        <Typography
+          variant="h5"
+          color={result === 0 ? "primary.main" : "warning.dark"}
+          display="flex"
+          justifyContent="center"
+        >
+          {JUDGEMENT[result as keyof typeof JUDGEMENT]}
+        </Typography>
+      </Box>
+    </ItemCard>
+  );
+}

--- a/app/components/judge-throw-away/judge-throw-away-list.tsx
+++ b/app/components/judge-throw-away/judge-throw-away-list.tsx
@@ -5,16 +5,14 @@ type TProps = {
   judgedItems: TItemsJudgeThrowAwayResponse[];
 };
 export default function JudgeThrowAwayList({ judgedItems }: TProps) {
-  return judgedItems.map((item: TItemsJudgeThrowAwayResponse) => {
-    return (
-      <JudgeThrowAwayListItem
-        key={item.item.id}
-        result={item.result}
-        item={item.item}
-        condition={item.condition}
-        repairMethod={item.repairMethod}
-        costDifference={item.costDifference}
-      />
-    );
-  });
+  return judgedItems.map((item: TItemsJudgeThrowAwayResponse) => (
+    <JudgeThrowAwayListItem
+      key={item.item.id}
+      result={item.result}
+      item={item.item}
+      condition={item.condition}
+      repairMethod={item.repairMethod}
+      costDifference={item.costDifference}
+    />
+  ));
 }

--- a/app/components/judge-throw-away/judge-throw-away-list.tsx
+++ b/app/components/judge-throw-away/judge-throw-away-list.tsx
@@ -1,0 +1,20 @@
+import { TItemsJudgeThrowAwayResponse } from "@/app/api/judge_throw_away/useItemsJudgeThrowAway";
+import JudgeThrowAwayListItem from "./judge-throw-away-list-item";
+
+type TProps = {
+  judgedItems: TItemsJudgeThrowAwayResponse[];
+};
+export default function JudgeThrowAwayList({ judgedItems }: TProps) {
+  return judgedItems.map((item: TItemsJudgeThrowAwayResponse) => {
+    return (
+      <JudgeThrowAwayListItem
+        key={item.item.id}
+        result={item.result}
+        item={item.item}
+        condition={item.condition}
+        repairMethod={item.repairMethod}
+        costDifference={item.costDifference}
+      />
+    );
+  });
+}


### PR DESCRIPTION
ご確認よろしくお願いします！
<img width="332" alt="スクリーンショット 2023-09-11 1 39 34" src="https://github.com/KiizanKiizan/Manene/assets/105505578/85bd2192-1fab-4dce-9c0e-01ae00c334c7">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

新機能:
- `JudgeThrowAwayListItem`という新しいコンポーネントを追加しました。このコンポーネントは、アイテムの詳細情報、判断条件、修理費用の差額、アイテムの使用回数などを表示するアイテムカードをレンダリングします。
- `JudgeThrowAwayList`という新しいコンポーネントを追加しました。このコンポーネントは、`judgedItems`という配列をプロップとして受け取り、その配列をマッピングして複数の`JudgeThrowAwayListItem`コンポーネントのインスタンスをレンダリングします。それぞれのインスタンスには、`judgedItems`配列の対応するアイテムに基づいた異なるプロップが渡されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->