### PR TITLE
fix: overflowを適応させて特定の範囲でスクロールできるようにする

### DIFF
--- a/app/components/stocktaking/stocktaking-container.tsx
+++ b/app/components/stocktaking/stocktaking-container.tsx
@@ -7,7 +7,7 @@ import {
 import useStocktakingsComplete from "@/app/api/stocktaking/useStocktakingsComplete";
 import useStocktakingsCreate from "@/app/api/stocktaking/useStocktakingsCreate";
 import CachedIcon from "@mui/icons-material/Cached";
-import { Button } from "@mui/material";
+import { Box, Button } from "@mui/material";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import BarcodeButton from "../common/barcode/barcode-button";
@@ -96,7 +96,12 @@ export default function StocktakingContainer({ locationList }: TProps) {
       </Header>
 
       {locations && (
-        <StocktakingList locations={locations} onClick={handleClickNavigate} />
+        <Box overflow="auto" height={700}>
+          <StocktakingList
+            locations={locations}
+            onClick={handleClickNavigate}
+          />
+        </Box>
       )}
       <FooterButton
         onClick={locations ? onClickComplete : onClickStart}


### PR DESCRIPTION
ご確認お願いします！

棚卸し完了ボタンと棚一覧のリストが被ってしまい押せない棚が存在するため、overflowを用いて棚リストを特定の範囲でスクロールさせるようにする

https://github.com/KiizanKiizan/Manene/assets/105505578/9bc0867c-f751-4419-8e1d-676fc3ef4a21



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- スタイル: `@mui/material`から`Box`コンポーネントをインポートし、`StocktakingList`コンポーネントを`Box`コンポーネントでラップする変更が行われました。これにより、リストの高さを制限し、必要に応じてスクロールを可能にすることでUIが改善されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->