### PR TITLE
型の修正

### DIFF
--- a/app/api/before-inspections/useBeforeInspectionsCreate.ts
+++ b/app/api/before-inspections/useBeforeInspectionsCreate.ts
@@ -14,7 +14,7 @@ export type TChartItem = {
   id: number;
   itemInfo: TItemInfo;
   purchasedFlag: boolean;
-  inspectionStatus: number;
+  inspectionStatus: number | null;
 };
 
 export type TChart = {

--- a/app/components/common/Item/item-info-card.tsx
+++ b/app/components/common/Item/item-info-card.tsx
@@ -12,7 +12,7 @@ type TProps = {
   onClick?: (id: number) => void;
   isLoading?: boolean;
   isPurchased?: boolean;
-  inspectionStatus?: number;
+  inspectionStatus?: number | null;
 };
 
 function InspectionStatusText({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- リファクタ: `TChartItem`インターフェースと`TProps`インターフェースの`inspectionStatus`プロパティの型を`number`から`number | null`に変更しました。これにより、`inspectionStatus`がnull値を持つことが可能になりました。この変更は、内部的なコードの改善であり、エンドユーザーには直接的な影響はありません。
---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->