### PR TITLE
fix: playwightのテストPR時に走らせないようにする

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,27 @@
-name: Playwright Tests
-on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
-jobs:
-  test:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - name: Install dependencies
-      run: yarn
-    - name: Install Playwright Browsers
-      run: yarn playwright install --with-deps
-    - name: Run Playwright tests
-      run: yarn playwright test
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+# name: Playwright Tests
+# on:
+#   push:
+#     branches: [ main, master ]
+#   pull_request:
+#     branches: [ main, master ]
+# jobs:
+#   test:
+#     timeout-minutes: 60
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/setup-node@v3
+#       with:
+#         node-version: 18
+#     - name: Install dependencies
+#       run: yarn
+#     - name: Install Playwright Browsers
+#       run: yarn playwright install --with-deps
+#     - name: Run Playwright tests
+#       run: yarn playwright test
+#     - uses: actions/upload-artifact@v3
+#       if: always()
+#       with:
+#         name: playwright-report
+#         path: playwright-report/
+#         retention-days: 30


### PR DESCRIPTION
ご確認お願いします！”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Chore: 一時的にPlaywrightテストワークフローが無効化されました。GitHub Actionsの設定ファイル内で、各行の先頭に"#"を追加することでコードがコメントアウトされました。この変更は一時的なものであり、テストの実行を一時停止する目的があります。ユーザーには直接的な影響はありませんが、開発者はテストの一時停止を認識する必要があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->